### PR TITLE
docs: move site from `user.github.io` to `slyde.js.org`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Slyde
 site_author: Tygo van den Hurk
-site_url: https://tygo-van-den-hurk.github.io/Slyde/
+site_url: https://slyde.js.org/
 site_description: Make beautifully animated Slydes and presentations from XML with ease!
 
 repo_url: https://github.com/Tygo-van-den-Hurk/Slyde


### PR DESCRIPTION
The js.org domain is shorter and makes `Slyde` not a subdirectory site. I also think it looks more professional. Can be merged when they merge pull request js-org/js.org#10514 into master.

<!-- ^ Please summarise the changes you have made and explain why they are necessary above here ^ -->

## Checklist

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Made sure my pull request fits [CONTRIBUTING.md].
- [x] Marked commits with `!` if they were breaking changes.
- [x] Updated the `docs/` when needed.
- [x] Added tests to `test/` for all new code.
- [x] This pull request does not fix a security issue. (See [SECURITY.md])

[CONTRIBUTING.md]: https://github.com/Tygo-van-den-Hurk/Slyde/blob/master/CONTRIBUTING.md
[SECURITY.md]: https://github.com/Tygo-van-den-Hurk/Slyde/blob/master/SECURITY.md

## Meta data

Built on platform (select all applicable):
- [x] Linux (x86_64)
- [x] Linux (aarch64)
- [x] Macos (x86_64)
- [x] Macos (aarch64)
- [x] Windows (x86_64)
- [x] Windows (aarch64)
- [ ] other: ...

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/Tygo-van-den-Hurk/Slyde/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
