### PR TITLE
fix(ci): latest tag docker does not move to newest version

### DIFF
--- a/.github/workflows/many--build-and-push-image.yaml
+++ b/.github/workflows/many--build-and-push-image.yaml
@@ -49,7 +49,7 @@ jobs:
               echo "tags=$VERSION" >> $GITHUB_OUTPUT
             elif [[ "$VERSION" == *.*.* ]]; then
               IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-              tags="$MAJOR.$MINOR.$PATCH,$MAJOR.$MINOR,$MAJOR"
+              tags="latest,$MAJOR.$MINOR.$PATCH,$MAJOR.$MINOR,$MAJOR"
               echo "tags=$tags" >> $GITHUB_OUTPUT
             else
               echo "Tag: '$VERSION' is not a semver."


### PR DESCRIPTION
When you created a new version of Slyde then the `latest` tag did not move to that new version. The major and minor tags do move. So for example if you pushed `v1.2.3` then `1`, `1.2`, and `1.2.3` do get created/moved, but the `latest` tag does not, it does now.

fixes #13: latest tag docker does not move to newest version

<!-- ^ Please summarise the changes you have made and explain why they are necessary above here ^ -->

## Checklist

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Made sure my pull request fits [CONTRIBUTING.md].
- [x] Marked commits with `!` if they were breaking changes.
- [x] Updated the `docs/` when needed.
- [x] Added tests to `test/` for all new code.
- [x] This pull request does not fix a security issue. (See [SECURITY.md])

[CONTRIBUTING.md]: https://github.com/Tygo-van-den-Hurk/Slyde/blob/master/CONTRIBUTING.md
[SECURITY.md]: https://github.com/Tygo-van-den-Hurk/Slyde/blob/master/SECURITY.md

## Meta data

Built on platform (select all applicable):
- [ ] Linux (x86_64)
- [ ] Linux (aarch64)
- [ ] Macos (x86_64)
- [ ] Macos (aarch64)
- [ ] Windows (x86_64)
- [ ] Windows (aarch64)
- [ ] other: ...

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/Tygo-van-den-Hurk/Slyde/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
