### PR TITLE
docs(coc): add report link to code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -43,7 +43,7 @@ We agree to restrict the following behaviors in our community. Instances, threat
 
 Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
 
-When an incident does occur, it is important to report it promptly. To report a possible violation, **[NOTE: describe your means of reporting here.]**
+When an incident does occur, it is important to report it promptly. To report a possible violation, [contact me](https://redirects.tygo.van.den.hurk.dev/contact).
 
 Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
 


### PR DESCRIPTION
Added a link to report violations of the code of conduct in the code of conduct. Before there was still unchanged part of the template: "When an incident does occur, it is important to report it promptly. To report a possible violation, [NOTE: describe your means of reporting here.]" Which isn't all that helpful.

fixes #15: docs(coc): add report link to code of conduct

<!-- ^ Please summarise the changes you have made and explain why they are necessary above here ^ -->

## Checklist

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Made sure my pull request fits [CONTRIBUTING.md].
- [x] Marked commits with `!` if they were breaking changes.
- [x] Updated the `docs/` when needed.
- [x] Added tests to `test/` for all new code.
- [x] This pull request does not fix a security issue. (See [SECURITY.md])

[CONTRIBUTING.md]: https://github.com/Tygo-van-den-Hurk/Slyde/blob/master/CONTRIBUTING.md
[SECURITY.md]: https://github.com/Tygo-van-den-Hurk/Slyde/blob/master/SECURITY.md

## Meta data

Built on platform (select all applicable):
- [ ] Linux (x86_64)
- [ ] Linux (aarch64)
- [ ] Macos (x86_64)
- [ ] Macos (aarch64)
- [ ] Windows (x86_64)
- [ ] Windows (aarch64)
- [ ] other: ...

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/Tygo-van-den-Hurk/Slyde/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
